### PR TITLE
Fix URL of Wotton House website

### DIFF
--- a/links.md
+++ b/links.md
@@ -5,7 +5,7 @@
 [LSCC]: http://www.meetup.com/london-software-craftsmanship/
 [open_space_unconference]: https://en.wikipedia.org/wiki/Open_Space_Technology
 
-[WottonHouse]: http://www.wottonhousedorkingsurrey.co.uk/
+[WottonHouse]: https://www.ihg.com/spnd/hotels/us/en/guildford/guidw/hoteldetail
 [WottonGoogleMaps]: https://www.google.co.uk/maps/place/Wotton+House/@51.210842,-0.3960782,135m/data=!3m1!1e3!4m7!1m4!3m3!1s0x0:0x0!2zNTHCsDEyJzM5LjIiTiAwwrAyMyc0NC42Ilc!3b1!3m1!1s0x0000000000000000:0x9b7aa884271af6b5!6m1!1e1?hl=en
 
 [tickets_page]: tickets.html

--- a/location.md
+++ b/location.md
@@ -62,7 +62,7 @@ T: +44 (0) 1306 730 000
 
 The best place to find out how to get there is [Wotton House's site][WottonHouse].
 
-[WottonHouse]: http://www.wottonhousedorkingsurrey.co.uk/location/
+[WottonHouse]: https://www.ihg.com/spnd/hotels/us/en/guildford/guidw/hoteldetail
 
 The nearest station is Dorking station. It is 3-4 miles and 15 minutes’ drive away. A one way taxi should cost between £12 and £30 depending on traffic.
 

--- a/location.md
+++ b/location.md
@@ -62,8 +62,6 @@ T: +44 (0) 1306 730 000
 
 The best place to find out how to get there is [Wotton House's site][WottonHouse].
 
-[WottonHouse]: https://www.ihg.com/spnd/hotels/us/en/guildford/guidw/hoteldetail
-
 The nearest station is Dorking station. It is 3-4 miles and 15 minutes’ drive away. A one way taxi should cost between £12 and £30 depending on traffic.
 
 Please check our wiki for the [local taxi companies][]. __Please note that most taxis near Dorking Station don’t accept cards and the only cash machine to withdraw the money at the station is usually out of service, so make sure you have cash on hand.__


### PR DESCRIPTION
It looks like the previous URL redirects to DeVere, which does not
seem to run Wotton House anymore.