### PR TITLE
Fix navbar toggle on mobile

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -6,7 +6,7 @@
         <span class="navbar-toggler-icon"></span>
     </button>
 
-    <div class="collapse navbar-collapse navbar-responsive-collapse">
+    <div class="collapse navbar-collapse navbar-responsive-collapse" id="navbarSupportedContent">
       <ul class="nav navbar-nav navbar-right">
         <li {% if page.title == 'Home' %} class="nav-item active"{% endif %}><a class="nav-link" href="index.html">Home</a></li>
         <li {% if page.title == 'Code Of Conduct' %} class="nav-item active"{% endif %}><a class="nav-link" href="code_of_conduct.html">Code Of Conduct</a></li>


### PR DESCRIPTION
the id attribute was missing from the dropdown content on mobile so the menu wasn't able to be expanded

https://user-images.githubusercontent.com/100650/212924332-405eb437-ffb3-403d-9c89-b9c49b51ca72.mp4