### PR TITLE
Add a summary of the cost of the tickets to homepage

### DIFF
--- a/_includes/tickets.html
+++ b/_includes/tickets.html
@@ -7,7 +7,7 @@
 
     <p class="mt-5">The cost to attend is £725, which includes your accommodation and meals from Thursday diner til Sunday lunch.</p>
     <p>For those who wish to participate in the <a href="/training_day.html">training day</a> on Thursday, an additional fee of £358 applies.</p>
-    <p>If you would like to arrive at the venue the day before the event starts on Wednesday, you can pay an extra £110 for your Wednesday night accommodation, dinner, and breakfast.</p>
+    <p>If you would like to arrive at the venue on Wednesday, the day before the event starts, you can pay an extra £110 for your Wednesday night accommodation, dinner, and breakfast.</p>
     <p>We are constantly searching for sponsorships that could lower the cost of tickets. If successful, we will distribute the savings evenly among all attendees by issuing a refund for the difference as soon as we get the sponsor(s) confirmed. We'd love suggestions, here are our <a href="/sponsorship.html">packages</a> and how to <a href="/contact.html">get in touch</a>.</p>
 
 </div>

--- a/_includes/tickets.html
+++ b/_includes/tickets.html
@@ -5,7 +5,7 @@
 
     {% include ticket-provider.html %}
 
-    <p class="mt-5">The cost to attend is £725, which includes your accommodation and meals during the event.</p>
+    <p class="mt-5">The cost to attend is £725, which includes your accommodation and meals from Thursday diner til Sunday lunch.</p>
     <p>For those who wish to participate in the training day, an additional fee of £358 applies.</p>
     <p>If you would like to arrive at the venue the day before the event starts on Wednesday, you can pay an extra £110 for your Wednesday night accommodation, dinner, and breakfast.</p>
     <p>We are constantly searching for sponsorships that could lower the cost of tickets, and if successful, we will distribute the savings evenly among all attendees by issuing a refund for the difference after the event.</p>

--- a/_includes/tickets.html
+++ b/_includes/tickets.html
@@ -6,7 +6,7 @@
     {% include ticket-provider.html %}
 
     <p class="mt-5">The cost to attend is £725, which includes your accommodation and meals from Thursday diner til Sunday lunch.</p>
-    <p>For those who wish to participate in the training day, an additional fee of £358 applies.</p>
+    <p>For those who wish to participate in the <a href="/training_day.html">training day</a> on Thursday, an additional fee of £358 applies.</p>
     <p>If you would like to arrive at the venue the day before the event starts on Wednesday, you can pay an extra £110 for your Wednesday night accommodation, dinner, and breakfast.</p>
     <p>We are constantly searching for sponsorships that could lower the cost of tickets, and if successful, we will distribute the savings evenly among all attendees by issuing a refund for the difference after the event.</p>
 

--- a/_includes/tickets.html
+++ b/_includes/tickets.html
@@ -4,4 +4,10 @@
     <p>You can find all information about tickets <a href="/tickets.html">here</a>.</p>
 
     {% include ticket-provider.html %}
+
+    <p class="mt-5">The cost to attend is £725, which includes your accommodation and meals during the event.</p>
+    <p>For those who wish to participate in the training day, an additional fee of £358 applies.</p>
+    <p>If you would like to arrive at the venue the day before the event starts on Wednesday, you can pay an extra £110 for your Wednesday night accommodation, dinner, and breakfast.</p>
+    <p>We are constantly searching for sponsorships that could lower the cost of tickets, and if successful, we will distribute the savings evenly among all attendees by issuing a refund for the difference after the event.</p>
+
 </div>

--- a/_includes/tickets.html
+++ b/_includes/tickets.html
@@ -8,6 +8,6 @@
     <p class="mt-5">The cost to attend is £725, which includes your accommodation and meals from Thursday diner til Sunday lunch.</p>
     <p>For those who wish to participate in the <a href="/training_day.html">training day</a> on Thursday, an additional fee of £358 applies.</p>
     <p>If you would like to arrive at the venue the day before the event starts on Wednesday, you can pay an extra £110 for your Wednesday night accommodation, dinner, and breakfast.</p>
-    <p>We are constantly searching for sponsorships that could lower the cost of tickets, and if successful, we will distribute the savings evenly among all attendees by issuing a refund for the difference after the event.</p>
+    <p>We are constantly searching for sponsorships that could lower the cost of tickets. If successful, we will distribute the savings evenly among all attendees by issuing a refund for the difference as soon as we get the sponsor(s) confirmed. We'd love suggestions, here are our <a href="/sponsorship.html">packages</a> and how to <a href="/contact.html">get in touch</a>.</p>
 
 </div>


### PR DESCRIPTION
At the moment you can buy tickets on the homepage directly, however we only have information about the ticket price on the tickets page.

From the homepage you have to provide personal information to the typeform to be able to see the ticket price which people might avoid.

One bit I wasn't sure about - I narrowed down that the refund from sponsorships would happen " after the event" in case people were tempted to hold off purchasing a ticket because they thought the upfront cost before the event might go down. But is this actually how it would work? I guess implying the refund would be after the event is safe enough to do, because it's unlikely to cause a complaint if the refund comes early.

![localhost_4000_index html](https://user-images.githubusercontent.com/100650/218221646-7b7cf48e-a8bf-4c16-9318-7044b9635cce.png)
