### PR TITLE
Fix slack link in Contact & Code of Conduct

### DIFF
--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -76,7 +76,7 @@ If you need help, have any further questions or have any other concerns, please 
  * Find and talk to the organizers
  * Contact us on email [socratesuk-info@googlegroups.com][infomail]
  * Contact us in twitter [@SoCraTes_UK][twitter] (send a direct message)
- * Ask in the channel #ev_socratesuk on the [Software Crafters Slack][softwarecrafters]
+ * Ask in the channel #ev_socratesuk on the [Software Crafters Slack][software_crafters_slack]
  * Contact an organizer on Slack
 
 This code of conduct applies to the SoCraTes conference itself, and to all digital spaces that are related to the SoCraTes conference, such as the wiki and mailing list.

--- a/contact.md
+++ b/contact.md
@@ -13,4 +13,4 @@ Got a question? Get in touch and one of the team will get back to you as soon as
 Email: [socratesuk-info@googlegroups.com][infomail]  
 Mastodon: [SoCraTes_UK][mastodon]  
 Twitter: [SoCraTes_UK][twitter]  
-Slack: Channel `#ev_socratesuk` on the [Software Crafters Slack][softwarecrafters]
+Slack: Channel `#ev_socratesuk` on the [Software Crafters Slack][software_crafters_slack]

--- a/links.md
+++ b/links.md
@@ -2,7 +2,7 @@
 [twitter]: https://twitter.com/socrates_uk
 [mastodon]: https://discuss.systems/@SoCraTes_UK
 [twitter_socrates_hashtag]: https://twitter.com/hashtag/SoCraTesUK
-[softwarecrafters]: https://www.softwarecrafters.org/
+[software_crafters_slack]: https://slack.softwarecrafters.org/
 [LSCC]: http://www.meetup.com/london-software-craftsmanship/
 [open_space_unconference]: https://en.wikipedia.org/wiki/Open_Space_Technology
 


### PR DESCRIPTION
Made it point to https://slack.softwarecrafters.org/ rather than https://www.softwarecrafters.org/