### PR TITLE
Update partner event dates for upcoming editions

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,7 @@ partner_events:
 
   - title: SoCraTes Switzerland
     website: https://www.socrates-ch.org/
-    date: January 29th - February 1st 2026
+    date: January 28th - 31st 2027
     location: Ilanz, Switzerland
 
   - title: SoCraTes France
@@ -53,12 +53,12 @@ partner_events:
 
   - title: JS CraftCamp
     website: http://jscraftcamp.org/
-    date: June 27th - 28th 2025
+    date: June 12th - 13th 2026
     location: Munich, Germany
 
   - title: SoCraTes Germany
     website: https://www.socrates-conference.de/
-    date: July 17th - 20th  2025
+    date: August 27th - 30th 2026
     location: Soltau, Germany
 
   - title: SoCraTes Maroc
@@ -78,17 +78,17 @@ partner_events:
 
   - title: SoCraTes Austria
     website: https://socrates-conference.at/
-    date: September 26th - 27th 2025
+    date: September 25th - 26th 2026
     location: Linz, Austria
 
   - title: CITCON (Continuous Integration and Testing unConference)
     website: https://citconf.com/
-    date: September 26th - 27th 2025
-    location: London (Woking), UK
+    date: May 22nd - 23rd 2026
+    location: Helsinki, Finland
 
   - title: SoCraTes Italy
     website: https://www.socrates-conference.it/
-    date:  October 2nd - 4th 2025
+    date: September 17th - 19th 2026
     location: Rimini, Italy
 
   - title: SoCraTes Canada


### PR DESCRIPTION
## Summary

Verified all 18 partner-event links in the "Are there any other SoCraTes?" section and refreshed dates/locations for the live ones from their official sites.

## Date updates

| Event | Old | New |
|---|---|---|
| SoCraTes Switzerland | Jan 29 – Feb 1 2026 | Jan 28 – 31 2027 |
| JS CraftCamp | Jun 27 – 28 2025 | Jun 12 – 13 2026 |
| SoCraTes Germany | Jul 17 – 20 2025 | Aug 27 – 30 2026 |
| SoCraTes Austria | Sep 26 – 27 2025 | Sep 25 – 26 2026 |
| CITCON | Sep 26 – 27 2025, London (Woking) UK | May 22 – 23 2026, Helsinki Finland |
| SoCraTes Italy | Oct 2 – 4 2025 | Sep 17 – 19 2026 |

## Left unchanged

Official site shows no newer date than current config: CodeFreeze, SoCraTes FR, Maroc, Day Berlin, Canada, Belgium, Crete, FroGS. ITAKE site still shows May 2021 (likely defunct).

## Dead links (not touched — separate decision)

- **SoCraTes Canaries** (socracan.org) — 404
- **SoCraTes Day Chile** (socrates-conference.cl) — DNS gone
- **SoCraTes Day Switzerland** (socrates-day.ch) — domain parked on blank WordPress.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)