### PR TITLE
Roll front page over to SoCraTes UK 2027

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,8 +16,8 @@ sponsors:
     logo: runpath.png
 
 event_details:
-  year: 2026
-  date: June 18th - 21st
+  year: 2027
+  date: Dates to be announced
   location: Milton Hill House, Abingdon, OX13 6AF
 
 partner_events:

--- a/_includes/front-page-header.html
+++ b/_includes/front-page-header.html
@@ -10,7 +10,7 @@
         <h3 class="display-5">International Software Craft and Testing Unconference UK</h3>
         <h4 class="display-5">{{ site.event_details.location }}</h4><br>
 
-        <a href="/tickets.html#i-want-to-buy-my-ticket" class="btn btn-lg btn-danger fw-semibold">Register</a>
+        <a href="#tickets" class="btn btn-lg btn-danger fw-semibold">Join our mailing list</a>
         <a href="/index.html#content" class="text-white ms-4 text-decoration-underline fw-semibold">Tell me more</a>
 
         <div class="background-photo-credit text-center">

--- a/_includes/mailing-list.html
+++ b/_includes/mailing-list.html
@@ -1,0 +1,5 @@
+<!-- Existing MailerLite mailing list (shared with the newsletter sign-up) -->
+<div class="container text-center">
+    <div class="ml-embedded" data-form="OSdqEL"></div>
+    <small>powered by <a href="https://www.mailerlite.com" target="_blank">MailerLite</a></small>
+</div>

--- a/_includes/sponsors.html
+++ b/_includes/sponsors.html
@@ -19,7 +19,7 @@
     </div>
 
     <p class="lead">
-        <button class="btn btn-lg btn-warning" onclick="window.location = '/sponsorship.html'">I want to sponsor SoCraTes UK 2026</button>
+        <button class="btn btn-lg btn-warning" onclick="window.location = '/sponsorship.html'">I want to sponsor SoCraTes UK {{ site.event_details.year }}</button>
     </p>
 
 </div>

--- a/_includes/tickets.html
+++ b/_includes/tickets.html
@@ -1,20 +1,9 @@
 <div class="container text-center">
-    <h2 class="display-3">Where can I get a ticket?</h2>
+    <h2 class="display-3">SoCraTes UK {{ site.event_details.year }}</h2>
 
-    <p>You can find all information about tickets <a href="/tickets.html">here</a>.</p>
+    <p class="lead">We had a wonderful time at SoCraTes UK 2026, and we're already looking forward to next year.</p>
 
-    <p>⚠️ The UK introduced in 2025 an Electronic Travel Authorisation (ETA) that applies, amongst other people, to EU citizens.  <br />
-   Check <a href="https://www.gov.uk/guidance/apply-for-an-electronic-travel-authorisation-eta">the guidance</a>. We've also made a <a href="https://github.com/SoCraTesUK/socrates-uk/wiki/Entering-the-UK-%E2%80%90-ETA">wiki page</a> to share experiences applying.</p>
+    <p>Dates for SoCraTes UK {{ site.event_details.year }} are still to be announced. Join our mailing list below and you'll be the first to hear when they're confirmed and tickets open.</p>
 
-    {% include ticket-provider.html %}
-
-    <p class="mt-5">The cost to attend is £675, which includes your accommodation and meals from Thursday dinner til Sunday lunch.</p>
-
-    <p>Family and +1 options also available to come with your loved ones! Or a friend or colleague. See <a href="/tickets.html#how-much-does-it-cost">tickets</a> for more details.</p>
-
-    <p>For those who wish to participate in the <a href="/training_day.html">training day</a> on Thursday, an additional fee of £375 applies.</p>
-    <p>If you would like to arrive at the venue on Wednesday, the day before the event starts, you can pay an extra £110 for your Wednesday night accommodation, dinner, and breakfast.</p>
-
-    <p>We are constantly searching for sponsorships that could lower the cost of tickets. If successful, we will distribute the savings evenly among all attendees by issuing a refund for the difference as soon as we get the sponsor(s) confirmed. We'd love suggestions, here are our <a href="/sponsorship.html">packages</a> and how to <a href="/contact.html">get in touch</a>.</p>
-
+    <p>In the meantime, our <a href="https://github.com/SoCraTesUK/socrates-uk/wiki">wiki</a> has notes and shared experiences from past events.</p>
 </div>

--- a/_layouts/front-page.html
+++ b/_layouts/front-page.html
@@ -26,6 +26,7 @@
         <a name="tickets"></a>
         <div class="front-page-row front-page-tickets">
             {% include tickets.html %}
+            {% include mailing-list.html %}
         </div>
         <div class="front-page-social">
             {% include social.html %}


### PR DESCRIPTION
## What

The 2026 event is over, so this rolls the front page over to look forward to **SoCraTes UK 2027**.

- **`_config.yml`** — `year: 2027`, `date: Dates to be announced`
- **Hero button** — "Register" → "Join our mailing list" (scrolls to `#tickets`)
- **Tickets section** — a short past-tense wrap-up plus a "join our mailing list to hear when dates and tickets are confirmed" message, with a link to the wiki for notes from past events
- **`mailing-list.html`** — reuses the **existing** MailerLite mailing list (the newsletter form, `OSdqEL`) rather than standing up and maintaining a separate waiting-list form. (Agreed with Amélie.)
- **Sponsors CTA** — references the event year

## Rebased onto current `gh-pages`

This branch was originally cut before #168–#177 merged, so it was well behind. It has been rebased cleanly onto the latest `gh-pages`: it now changes **only the 6 files above**, and all work merged in the meantime — Bluesky/LinkedIn social, carousel captions, New to SoCraTes, hero tagline, meta tags, the Twitter→Bluesky sweep — is preserved untouched.

## Verified locally

Front page renders 2027 throughout, the hero button and tickets sign-up point at the existing mailing list (both it and the newsletter form populate at runtime), and the merged social/carousel/New-to-SoCraTes work is all still present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)