### PR TITLE
fix: update Wiki navbar link to current org and https

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -14,7 +14,7 @@
         <li {% if page.title == 'Tickets' %} class="nav-item active"{% endif %}><a class="nav-link" href="tickets.html">Tickets</a></li>
         <li {% if page.title == 'Location' %} class="nav-item active"{% endif %}><a class="nav-link" href="location.html">Location</a></li>
         <li {% if page.title == 'Sponsorship' %} class="nav-item active"{% endif %}><a class="nav-link" href="sponsorship.html">Sponsorship</a></li>
-        <li><a class="nav-link" href="http://github.com/lscc/socrates-uk/wiki" target="_blank">Wiki</a></li>
+        <li><a class="nav-link" href="https://github.com/SoCraTesUK/socrates-uk/wiki" target="_blank">Wiki</a></li>
         <li {% if page.title == 'Contact' %} class="nav-item active"{% endif %}><a class="nav-link" href="contact.html">Contact</a></li>
         <li {% if page.title == 'COVID policy' %} class="nav-item active"{% endif %}><a class="nav-link" href="covid_policy.html">COVID Policy</a></li>
       </ul>


### PR DESCRIPTION
## Summary
The navbar Wiki link pointed at the outdated `http://github.com/lscc/socrates-uk/wiki`. The project moved from the `lscc` org to `SoCraTesUK`, so that URL no longer resolves.

This updates the href to the current wiki, using `https`:
`https://github.com/SoCraTesUK/socrates-uk/wiki`

All other `<li>`/`<a>` attributes (`target="_blank"`, the "Wiki" text) are unchanged.

## Testing
No build/behavior change beyond the link target; single-line edit in `_includes/navbar.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)