### PR TITLE
Add and style front-page hero tagline

### DIFF
--- a/_includes/front-page-header.html
+++ b/_includes/front-page-header.html
@@ -7,7 +7,7 @@
         <h3 class="display-5">International Software Craft and Testing Unconference UK</h3>
         <h4 class="display-5">{{ site.event_details.location }}</h4><br>
 
-        <p class="lead">Three days of hands-on software craft, good conversations and community, in the English countryside.</p>
+        <p class="lead">Three days of hands-on software craft, great conversations and good company — in the English countryside.</p>
 
         <a href="/tickets.html#i-want-to-buy-my-ticket" class="btn btn-lg btn-danger fw-semibold">Register</a>
         <a href="/index.html#content" class="text-white ms-4 text-decoration-underline fw-semibold">Tell me more</a>

--- a/_includes/front-page-header.html
+++ b/_includes/front-page-header.html
@@ -6,7 +6,9 @@
         <h2 class="display-3">{{ site.event_details.date }}</h2>
         <h3 class="display-5">International Software Craft and Testing Unconference UK</h3>
         <h4 class="display-5">{{ site.event_details.location }}</h4><br>
-    
+
+        <p class="lead">Three days of hands-on software craft, good conversations and community, in the English countryside.</p>
+
         <a href="/tickets.html#i-want-to-buy-my-ticket" class="btn btn-lg btn-danger fw-semibold">Register</a>
         <a href="/index.html#content" class="text-white ms-4 text-decoration-underline fw-semibold">Tell me more</a>
 

--- a/_includes/front-page-header.html
+++ b/_includes/front-page-header.html
@@ -4,10 +4,11 @@
 
         <h1 class="socrates-brand display-1">SoCraTes UK {{ site.event_details.year }}</h1>
         <h2 class="display-3">{{ site.event_details.date }}</h2>
-        <h3 class="display-5">International Software Craft and Testing Unconference UK</h3>
-        <h4 class="display-5">{{ site.event_details.location }}</h4><br>
 
         <p class="lead">Three days of hands-on software craft, great conversations and good company — in the English countryside.</p>
+
+        <h3 class="display-5">International Software Craft and Testing Unconference UK</h3>
+        <h4 class="display-5">{{ site.event_details.location }}</h4><br>
 
         <a href="/tickets.html#i-want-to-buy-my-ticket" class="btn btn-lg btn-danger fw-semibold">Register</a>
         <a href="/index.html#content" class="text-white ms-4 text-decoration-underline fw-semibold">Tell me more</a>

--- a/css/custom/base.css
+++ b/css/custom/base.css
@@ -49,6 +49,19 @@
 	text-shadow: 3px 3px black;
 }
 
+.front-page-header .lead {
+	font-size: 2rem;
+	font-weight: 600;
+	text-shadow: 2px 2px 4px black, 0 0 6px black;
+}
+
+.front-page-header h3,
+.front-page-header h4 {
+	font-size: 1.15rem;
+	font-weight: 400;
+	text-shadow: 1px 1px 3px black, 0 0 4px black;
+}
+
 .front-page-header .socrates-brand {
 	font-family: 'PT Serif Caption', serif;
 }


### PR DESCRIPTION
## What

Adds a value-proposition tagline to the front-page hero and reworks the hero's text hierarchy and contrast so a first-time visitor immediately gets what SoCraTes UK is.

## Changes

**`_includes/front-page-header.html`**
- Adds a tagline: _"Three days of hands-on software craft, great conversations and good company — in the English countryside."_
- Places it directly under the date, **above** the "International Software Craft and Testing Unconference UK" and venue lines.

**`css/custom/base.css`** (header section)
- Makes the tagline the prominent line: `2rem`, semibold, with a legible drop shadow (`2px 2px 4px black, 0 0 6px black`) for the white-on-photo hero.
- Demotes the "International…" and "Milton Hill House…" descriptor lines to `1.15rem`, regular weight, with a softer, proportional shadow (`1px 1px 3px black, 0 0 4px black`) — the old heading `3px 3px` offset looked oversized on small text.

Net effect — hero reading order: **SoCraTes UK {year}** → **date** → **tagline** → quiet descriptor lines.

## Notes
- If the descriptor lines still feel marginal over the brightest part of the background photo, a subtle dark gradient behind the hero text is the more robust fix (not included here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)