### PR TITLE
feat: add attendee testimonials section to front page

### DIFF
--- a/_includes/testimonials.html
+++ b/_includes/testimonials.html
@@ -1,0 +1,22 @@
+<div class="container text-center">
+    <h2 class="display-3">What attendees say</h2>
+
+    <blockquote class="blockquote">
+        <p class="lead">Hope to participate again one day. Please keep it going!</p>
+        <footer class="blockquote-footer">Niklas Lochschmidt</footer>
+    </blockquote>
+
+    <!-- Add a real attendee quote here: "<quote>" — <name>
+    <blockquote class="blockquote">
+        <p class="lead"><quote></p>
+        <footer class="blockquote-footer"><name></footer>
+    </blockquote>
+    -->
+
+    <!-- Add a real attendee quote here: "<quote>" — <name>
+    <blockquote class="blockquote">
+        <p class="lead"><quote></p>
+        <footer class="blockquote-footer"><name></footer>
+    </blockquote>
+    -->
+</div>

--- a/_layouts/front-page.html
+++ b/_layouts/front-page.html
@@ -14,6 +14,9 @@
         <div class="front-page-row front-page-what-happens">
             {% include what-happens.html %}
         </div>
+        <div class="front-page-row front-page-testimonials">
+            {% include testimonials.html %}
+        </div>
         <div class="front-page-row front-page-sponsors">
             {% include sponsors.html %}
         </div>


### PR DESCRIPTION
## What

Adds a testimonials / social-proof section to the front page to help entice new attendees. The section sits immediately before the sponsors block and uses the site's standard `container text-center` section style.

- New partial `_includes/testimonials.html` with a "What attendees say" heading and one genuine attendee quote.
- Wired into `_layouts/front-page.html` before the sponsors section.

## Honesty note (please read)

Only **one** genuine attendee quote was available at the time of writing:

> "Hope to participate again one day. Please keep it going!" — Niklas Lochschmidt

Rather than fabricate additional testimonials, the include contains two **commented-out placeholder blocks**. Organisers should replace these with real attendee quotes and attributions before (or after) merge. Nothing fabricated is shown to visitors.

## Notes

- British English, no emoji, warm but understated copy.
- No changes to `Gemfile.lock` or vendored dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
