### PR TITLE
feat: add SEO and social share meta tags

### DIFF
--- a/_includes/html-head.html
+++ b/_includes/html-head.html
@@ -4,6 +4,21 @@
 
     <title>SoCraTes UK{% if page.title %} - {{ page.title }}{% endif %}</title>
 
+    <meta name="description" content="SoCraTes UK is a non-profit, international Software Crafters unconference and retreat for open-minded crafters who want to improve their craft and the software industry as a whole.">
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="SoCraTes UK{% if page.title %} - {{ page.title }}{% endif %}">
+    <meta property="og:description" content="SoCraTes UK is a non-profit, international Software Crafters unconference and retreat for open-minded crafters who want to improve their craft and the software industry as a whole.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://socratesuk.org{{ page.url }}">
+    <meta property="og:image" content="https://socratesuk.org/img/SoCraTes_UK_circle.png">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="SoCraTes UK{% if page.title %} - {{ page.title }}{% endif %}">
+    <meta name="twitter:description" content="SoCraTes UK is a non-profit, international Software Crafters unconference and retreat for open-minded crafters who want to improve their craft and the software industry as a whole.">
+    <meta name="twitter:image" content="https://socratesuk.org/img/SoCraTes_UK_circle.png">
+
     <link href="css/bootstrap/bootstrap.min.css" rel="stylesheet">
     <link href="css/custom/base.css" rel="stylesheet">
     <link href='http://fonts.googleapis.com/css?family=PT+Serif+Caption' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
## What

Adds SEO and social-share `<meta>` tags to `_includes/html-head.html`:

- `meta name="description"` summarising SoCraTes UK
- Open Graph tags: `og:title`, `og:description`, `og:type`, `og:url`, `og:image`
- Twitter card tags: `twitter:card` (summary_large_image), `twitter:title`, `twitter:description`, `twitter:image`

## Why

The site previously had almost no meta tags, so sharing a link (Slack, Mastodon, WhatsApp, etc.) produced a bare, unappealing preview. Rich previews with a title, description and image make shared links far more inviting, which matters for the conference's word-of-mouth growth.

## Notes

- `site.url` is not set in `_config.yml`, so the canonical domain (`https://socratesuk.org`, per `CNAME`) is hardcoded; `og:url` still uses `{{ page.url }}` so it is per-page correct.
- `og:image` / `twitter:image` point at the existing `img/SoCraTes_UK_circle.png`.
- Titles/descriptions reuse the existing dynamic `<title>` pattern where reasonable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)