### PR TITLE
Replace SoCraTes UK Twitter with Bluesky (sitewide)

### DIFF
--- a/_includes/aside.html
+++ b/_includes/aside.html
@@ -17,9 +17,4 @@
         </div>
         <em>Interested in sponsoring this year's event? </em><a href="/sponsorship.html">See the sponsorship page</a>.
     </section>
-    <section class="twitter-feed-aside">
-        <h3 class="page-header">Latest Tweets</h3>
-        <a class="twitter-timeline" href="https://twitter.com/SoCraTes_UK" data-widget-id="560047504235192320">Tweets by @SoCraTes_UK</a>
-        <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
-    </section>
 </aside>

--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -75,7 +75,7 @@ If you need help, have any further questions or have any other concerns, please 
 
  * Find and talk to the organizers
  * Contact us on email [socratesuk-info@googlegroups.com][infomail]
- * Contact us in twitter [@SoCraTes_UK][twitter] (send a direct message)
+ * Contact us on Bluesky [@socratesuk.bsky.social][bluesky] (send a direct message)
  * Ask in the channel #ev_socratesuk on the [Software Crafters Slack][software_crafters_slack]
  * Contact an organizer on Slack
 

--- a/contact.md
+++ b/contact.md
@@ -12,5 +12,5 @@ Got a question? Get in touch and one of the team will get back to you as soon as
 
 Email: [socratesuk-info@googlegroups.com][infomail]  
 Mastodon: [SoCraTes_UK][mastodon]  
-Twitter: [SoCraTes_UK][twitter]  
+Bluesky: [SoCraTes_UK][bluesky]  
 Slack: Channel `#ev_socratesuk` on the [Software Crafters Slack][software_crafters_slack]

--- a/links.md
+++ b/links.md
@@ -1,5 +1,6 @@
 [infomail]: mailto:socratesuk-info@googlegroups.com
 [twitter]: https://twitter.com/socrates_uk
+[bluesky]: https://bsky.app/profile/socratesuk.bsky.social
 [mastodon]: https://discuss.systems/@SoCraTes_UK
 [twitter_socrates_hashtag]: https://twitter.com/hashtag/SoCraTesUK
 [software_crafters_slack]: https://slack.softwarecrafters.org/

--- a/links.md
+++ b/links.md
@@ -1,8 +1,6 @@
 [infomail]: mailto:socratesuk-info@googlegroups.com
-[twitter]: https://twitter.com/socrates_uk
 [bluesky]: https://bsky.app/profile/socratesuk.bsky.social
 [mastodon]: https://discuss.systems/@SoCraTes_UK
-[twitter_socrates_hashtag]: https://twitter.com/hashtag/SoCraTesUK
 [software_crafters_slack]: https://slack.softwarecrafters.org/
 [LSCC]: http://www.meetup.com/london-software-craftsmanship/
 [open_space_unconference]: https://en.wikipedia.org/wiki/Open_Space_Technology


### PR DESCRIPTION
## What

Removes SoCraTes UK's own Twitter presence across the site, pointing people to Bluesky (`@socratesuk.bsky.social`) instead — following on from the front-page move to Bluesky in #168.

## Changed

- **`contact.md`** — `Twitter: [SoCraTes_UK]` → `Bluesky: [SoCraTes_UK]`
- **`code_of_conduct.md`** — the "contact us" line now points at Bluesky (with DM) instead of Twitter
- **`links.md`** — added `[bluesky]` definition; removed the now-unused `[twitter]` and `[twitter_socrates_hashtag]` definitions
- **`_includes/aside.html`** — removed the stale "Latest Tweets" timeline widget (this include is not used by any layout, but swept for completeness)

## Deliberately left untouched

These are either not ours to change or would cause harm to remove — flagged for the record:

- **`_includes/html-head.html`** — the `twitter:card` / `twitter:title` **meta tags**. These are share-preview metadata read by many platforms; removing them breaks link previews. Not a "presence" link.
- **`_includes/what-happens.html`** — ~15 **photo/session credits** linking to *other people's* Twitter (Matthew Butt, Esko Luontola, Denise Yu, etc.). Removing strips attribution and we don't have their Bluesky.
- **`digital-2020-spring.md` / `digital-2020-autumn.md`** — **historical event recaps**; rewriting dated archives misrepresents what happened. (One "reach out via twitter" CTA lives here — happy to update just that if wanted.)
- **`_includes/privacy_policy_export.html`** — lists "Twitter Inc." as a data processor (legal doc — worth a separate, considered review).
- **`css/bootstrap/…`** — Bootstrap's copyright header ("© Twitter, Inc."), unrelated.

## Verified

Local Jekyll build: contact and Code of Conduct pages render the Bluesky links, no literal `[twitter]` reference leaks, and `twitter.com/socrates_uk` no longer appears on those pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)